### PR TITLE
HDP-65 | Disable readiness and health traces from uwsgi

### DIFF
--- a/devices/.prod/uwsgi.ini
+++ b/devices/.prod/uwsgi.ini
@@ -8,3 +8,6 @@ master = 1
 processes = 2
 threads = 2
 static-map = /static=/app/static
+; don't log readiness and healtzh endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:

--- a/endpoint/.prod/uwsgi.ini
+++ b/endpoint/.prod/uwsgi.ini
@@ -7,3 +7,6 @@ gid = nogroup
 master = 1
 processes = 2
 threads = 2
+; don't log readiness and healtzh endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:

--- a/persister/.prod/uwsgi.ini
+++ b/persister/.prod/uwsgi.ini
@@ -8,3 +8,6 @@ master = 1
 processes = 2
 threads = 2
 static-map = /static=/app/static
+; don't log readiness and healtzh endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:


### PR DESCRIPTION
Disabled readiness and health checks as per the example in https://github.com/City-of-Helsinki/kuva-demo-project/blob/main/djangoapp/.prod/uwsgi.ini

This makes the logs easier to follow as there are fewer uninteresting lines that create noise.

